### PR TITLE
list supporting backends

### DIFF
--- a/src/openeo_aggregator/backend.py
+++ b/src/openeo_aggregator/backend.py
@@ -93,10 +93,12 @@ class AggregatorCollectionCatalog(AbstractCollectionCatalog):
         collections_metadata = []
         internal_data = _InternalCollectionMetadata()
         for cid, by_backend in grouped.items():
+            # TODO: don't differentiate between single and multi-backend case
             if len(by_backend) == 1:
                 # Simple case: collection is only available on single backend.
                 _log.debug(f"Accept single backend collection {cid} as is")
                 (bid, metadata), = by_backend.items()
+                metadata["backends"] = [bid]
             else:
                 _log.info(f"Merging {cid!r} collection metadata from backends {by_backend.keys()}")
                 metadata = self._merge_collection_metadata(by_backend)
@@ -161,6 +163,8 @@ class AggregatorCollectionCatalog(AbstractCollectionCatalog):
             # TODO: use a more robust/user friendly backend pointer than backend id (which is internal implementation detail)
             self.STAC_PROPERTY_PROVIDER_BACKEND: list(by_backend.keys())
         }
+        # TODO: #10 proper schema of this backend listing?
+        result["backends"] = list(by_backend.keys())
         # TODO: assets ?
 
         return result

--- a/src/openeo_aggregator/backend.py
+++ b/src/openeo_aggregator/backend.py
@@ -322,6 +322,8 @@ class AggregatorProcessing(Processing):
 
         process_registry = ProcessRegistry()
         for pid, spec in combined_processes.items():
+            # TODO: #10 proper schema of this backend listing?
+            spec["backends"] = [bid for bid, procs in processes_per_backend.items() if pid in procs]
             process_registry.add_spec(spec=spec)
 
         return process_registry

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -370,9 +370,21 @@ class TestAggregatorProcessing:
         processing = AggregatorProcessing(backends=multi_backend_connection, catalog=catalog)
         registry = processing.get_process_registry(api_version="1.0.0")
         assert sorted(registry.get_specs(), key=lambda p: p["id"]) == [
-            {"id": "add", "parameters": [{"name": "x"}, {"name": "y"}]},
-            {"id": "mean", "parameters": [{"name": "data"}]},
-            {"id": "multiply", "parameters": [{"name": "x"}, {"name": "y"}]},
+            {
+                "id": "add",
+                "parameters": [{"name": "x"}, {"name": "y"}],
+                "backends": ["b1"],
+            },
+            {
+                "id": "mean",
+                "parameters": [{"name": "data"}],
+                "backends": ["b1", "b2"],
+            },
+            {
+                "id": "multiply",
+                "parameters": [{"name": "x"}, {"name": "y"}],
+                "backends": ["b2"],
+            },
         ]
 
     def test_get_process_registry_parameter_differences(
@@ -391,7 +403,19 @@ class TestAggregatorProcessing:
         processing = AggregatorProcessing(backends=multi_backend_connection, catalog=catalog)
         registry = processing.get_process_registry(api_version="1.0.0")
         assert sorted(registry.get_specs(), key=lambda p: p["id"]) == [
-            {"id": "add", "parameters": [{"name": "x"}, {"name": "y"}]},
-            {"id": "mean", "parameters": [{"name": "array"}]},
-            {"id": "multiply", "parameters": [{"name": "x"}, {"name": "y"}]},
+            {
+                "id": "add",
+                "parameters": [{"name": "x"}, {"name": "y"}],
+                "backends": ["b1"],
+            },
+            {
+                "id": "mean",
+                "parameters": [{"name": "array"}],
+                "backends": ["b1", "b2"],
+            },
+            {
+                "id": "multiply",
+                "parameters": [{"name": "x"}, {"name": "y"}],
+                "backends": ["b2"],
+            },
         ]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -150,7 +150,10 @@ class TestAggregatorCollectionCatalog:
         requests_mock.get(backend2 + "/collections", json={"collections": [{"id": "S3"}]})
         catalog = AggregatorCollectionCatalog(backends=multi_backend_connection)
         metadata = catalog.get_all_metadata()
-        assert metadata == [{"id": "S2"}, {"id": "S3"}]
+        assert metadata == [
+            {"id": "S2", "backends": ["b1"]},
+            {"id": "S3", "backends": ["b2"]},
+        ]
 
     def test_get_all_metadata_common_collections_minimal(
             self, multi_backend_connection, backend1, backend2, requests_mock
@@ -160,16 +163,23 @@ class TestAggregatorCollectionCatalog:
         catalog = AggregatorCollectionCatalog(backends=multi_backend_connection)
         metadata = catalog.get_all_metadata()
         assert metadata == [
-            {"id": "S3"},
+            {
+                "id": "S3",
+                "backends": ["b1"],
+            },
             {
                 "id": "S4", "description": "S4", "title": "S4",
                 "stac_version": "0.9.0",
                 "extent": {"spatial": {"bbox": [[-180, -90, 180, 90]]}, "temporal": {"interval": [[None, None]]}},
                 "license": "proprietary",
                 "summaries": {"provider:backend": ["b1", "b2"]},
+                "backends": ["b1", "b2"],
                 "links": [],
             },
-            {"id": "S5"},
+            {
+                "id": "S5",
+                "backends": ["b2"],
+            },
         ]
 
     def test_get_all_metadata_common_collections_merging(
@@ -224,6 +234,7 @@ class TestAggregatorCollectionCatalog:
                 "license": "various",
                 "providers": [{"name": "ESA", "roles": ["producer"]}, {"name": "ESA", "roles": ["licensor"]}],
                 "summaries": {"provider:backend": ["b1", "b2"]},
+                "backends": ["b1", "b2"],
                 "links": [
                     {"rel": "license", "href": "https://spdx.org/licenses/MIT.html"},
                     {"rel": "license", "href": "https://spdx.org/licenses/Apache-1.0.html"},
@@ -279,6 +290,7 @@ class TestAggregatorCollectionCatalog:
             "extent": {"spatial": {"bbox": [[-180, -90, 180, 90]]}, "temporal": {"interval": [[None, None]]}},
             "license": "proprietary",
             "summaries": {"provider:backend": ["b1", "b2"]},
+            "backends": ["b1", "b2"],
             "links": [],
         }
 
@@ -300,6 +312,7 @@ class TestAggregatorCollectionCatalog:
             "extent": {"spatial": {"bbox": [[-180, -90, 180, 90]]}, "temporal": {"interval": [[None, None]]}},
             "license": "proprietary",
             "summaries": {"provider:backend": ["b2"]},
+            "backends": ["b2"],
             "links": [],
         }
         # TODO: test that caching of result is different from merging without error? (#2)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -229,9 +229,21 @@ class TestProcessing:
         res = api100.get("/processes").assert_status_code(200).json
         assert res == {
             "processes": [
-                {"id": "multiply", "parameters": [{"name": "x"}, {"name": "y"}]},
-                {"id": "mean", "parameters": [{"name": "data"}]},
-                {"id": "add", "parameters": [{"name": "x"}, {"name": "y"}]},
+                {
+                    "id": "multiply",
+                    "parameters": [{"name": "x"}, {"name": "y"}],
+                    "backends": ["b2"],
+                },
+                {
+                    "id": "mean",
+                    "parameters": [{"name": "data"}],
+                    "backends": ["b1", "b2"],
+                },
+                {
+                    "id": "add",
+                    "parameters": [{"name": "x"}, {"name": "y"}],
+                    "backends": ["b1"],
+                },
             ],
             "links": [],
         }


### PR DESCRIPTION
POC for issue #10 

- list supporting backends in collection metadata
- list supporting backends in process metadata

now listed as 
```
   "backends": ["vito", "eodc"],
```

Open for discussion: field `"backends"`, and what identifier to use for backends 