### PR TITLE
Issue84 cache service types and select correct backend

### DIFF
--- a/src/openeo_aggregator/backend.py
+++ b/src/openeo_aggregator/backend.py
@@ -652,12 +652,11 @@ class AggregatorSecondaryServices(SecondaryServices):
             config: AggregatorConfig
     ):
         super(AggregatorSecondaryServices, self).__init__()
-        self._backends = backends
 
+        self._backends = backends
         self._memoizer = memoizer_from_config(config=config, namespace="SecondaryServices")
         self._backends.on_connections_change.add(self._memoizer.invalidate)
 
-        # TODO Issue #84 Decide which backend based on service type. Will need to remove self._processing for this.
         self._processing = processing
 
     def _get_connection_and_backend_service_id(
@@ -804,6 +803,7 @@ class AggregatorSecondaryServices(SecondaryServices):
         #       Instead, properly determine backend based on service type?
         #       See https://github.com/Open-EO/openeo-aggregator/issues/78#issuecomment-1326180557
         #       and https://github.com/Open-EO/openeo-aggregator/issues/83
+        #       Should be able to remove this hardcoded workaround once issue #85 has been implemented.
         if "sentinelhub" in self._backends._backend_urls:
             backend_id = "sentinelhub"
         else:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -134,7 +134,7 @@ class TestAggregatorSecondaryServices:
     # TODO: most tests here (the ones that do flask app stuff and auth)
     #       belong under test_views.py
 
-    WMTS_SERVICE_TYPE = {
+    SERVICE_TYPES_ONLT_WMTS = {
         "WMTS": {
             "configuration": {
                 "colormap": {
@@ -162,7 +162,7 @@ class TestAggregatorSecondaryServices:
         """Given 2 backends and only 1 backend has a single service type, then the aggregator
             returns that 1 service type's metadata.
         """
-        single_service_type = self.WMTS_SERVICE_TYPE
+        single_service_type = self.SERVICE_TYPES_ONLT_WMTS
         requests_mock.get(backend1 + "/service_types", json=single_service_type)
         requests_mock.get(backend2 + "/service_types", json={})
         processing = AggregatorProcessing(backends=multi_backend_connection, catalog=catalog, config=config)
@@ -174,12 +174,13 @@ class TestAggregatorSecondaryServices:
     def test_service_types_simple_cached(
         self, multi_backend_connection, config, catalog, backend1, backend2, requests_mock
     ):
-        """The service_types call is cached:
+        """Scenario: The service_types call is cached:
             When we get the service types several times, the second call that happens before the cache expires,
             doesn't hit the backend.
             But the third call that happens that happens after the cache has expired does hit the backend again.
         """
-        single_service_type = self.WMTS_SERVICE_TYPE
+        # Just need one service type for the test.
+        single_service_type = self.SERVICE_TYPES_ONLT_WMTS
         mock_be1 = requests_mock.get(backend1 + "/service_types", json=single_service_type)
         processing = AggregatorProcessing(backends=multi_backend_connection, catalog=catalog, config=config)
         implementation = AggregatorSecondaryServices(backends=multi_backend_connection, processing=processing, config=config)
@@ -351,7 +352,7 @@ class TestAggregatorSecondaryServices:
             },
             status_code=201
         )
-        requests_mock.get(backend1 + "/service_types", json=self.WMTS_SERVICE_TYPE)
+        requests_mock.get(backend1 + "/service_types", json=self.SERVICE_TYPES_ONLT_WMTS)
         processing = AggregatorProcessing(backends=multi_backend_connection, catalog=catalog, config=config)
         implementation = AggregatorSecondaryServices(backends=multi_backend_connection, processing=processing, config=config)
 
@@ -371,7 +372,7 @@ class TestAggregatorSecondaryServices:
         """When it gets a request for a service type that no backend supports, it raises ServiceUnsupportedException."""
 
         # Set up one service type. Don't want test to succeed because there are no services at all.
-        requests_mock.get(backend1 + "/service_types", json=self.WMTS_SERVICE_TYPE)
+        requests_mock.get(backend1 + "/service_types", json=self.SERVICE_TYPES_ONLT_WMTS)
 
         non_existent_service_id =  "b1-doesnotexist"
         # check that this requests_mock does not get called
@@ -413,7 +414,7 @@ class TestAggregatorSecondaryServices:
             backend1 + "/services",
             exc=exception_class("Some server error"),
         )
-        requests_mock.get(backend1 + "/service_types", json=self.WMTS_SERVICE_TYPE)
+        requests_mock.get(backend1 + "/service_types", json=self.SERVICE_TYPES_ONLT_WMTS)
         processing = AggregatorProcessing(backends=multi_backend_connection, catalog=catalog, config=config)
         implementation = AggregatorSecondaryServices(backends=multi_backend_connection, processing=processing, config=config)
 
@@ -445,7 +446,7 @@ class TestAggregatorSecondaryServices:
             backend1 + "/services",
             exc=exception_class("Some server error")
         )
-        requests_mock.get(backend1 + "/service_types", json=self.WMTS_SERVICE_TYPE)
+        requests_mock.get(backend1 + "/service_types", json=self.SERVICE_TYPES_ONLT_WMTS)
         processing = AggregatorProcessing(backends=multi_backend_connection, catalog=catalog, config=config)
         implementation = AggregatorSecondaryServices(backends=multi_backend_connection, processing=processing, config=config)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1363,7 +1363,7 @@ class TestSecondaryServices:
             # not setting "created": This is used to test creating a service.
         )
 
-    WMTS_SERVICE_TYPE = {
+    SERVICE_TYPES_ONLT_WMTS = {
         "WMTS": {
             "configuration": {
                 "colormap": {
@@ -1389,27 +1389,8 @@ class TestSecondaryServices:
         """Given 2 backends but only 1 backend has a single service, then the aggregator
             returns that 1 service's metadata.
         """
-        single_service_type = {
-            "WMTS": {
-                "configuration": {
-                    "colormap": {
-                        "default": "YlGn",
-                        "description":
-                        "The colormap to apply to single band layers",
-                        "type": "string"
-                    },
-                    "version": {
-                        "default": "1.0.0",
-                        "description": "The WMTS version to use.",
-                        "enum": ["1.0.0"],
-                        "type": "string"
-                    }
-                },
-                "links": [],
-                "process_parameters": [],
-                "title": "Web Map Tile Service"
-            }
-        }
+        # Only need a single service type.
+        single_service_type = self.SERVICE_TYPES_ONLT_WMTS
         requests_mock.get(backend1 + "/service_types", json=single_service_type)
         requests_mock.get(backend2 + "/service_types", json={})
 
@@ -1725,7 +1706,7 @@ class TestSecondaryServices:
             },
             status_code=201
         )
-        requests_mock.get(backend1 + "/service_types", json=self.WMTS_SERVICE_TYPE)
+        requests_mock.get(backend1 + "/service_types", json=self.SERVICE_TYPES_ONLT_WMTS)
 
         resp = api100.post('/services', json=post_data).assert_status_code(201)
 
@@ -1822,7 +1803,7 @@ class TestSecondaryServices:
             backend1 + "/services",
             exc=exception_class("Testing exception handling")
         )
-        requests_mock.get(backend1 + "/service_types", json=self.WMTS_SERVICE_TYPE)
+        requests_mock.get(backend1 + "/service_types", json=self.SERVICE_TYPES_ONLT_WMTS)
 
         resp = api100.post('/services', json=post_data)
         assert resp.status_code == 500


### PR DESCRIPTION
# Cache service types and select correct backend based on service type.

This PR implements issue #84
And these changes also helps prepare the way for #85.

## Changes

1) Added caching to AggregatorSecondaryServices.service_types,  AKA:   GET  /services
2) create_service:  now determines which upstream backend to based on service type. (And only on service type, for now)
This works on the assumption that there is only one upstream backend per service type.

Internally, the service type info that is being cached actually contains info for both points 1) and 2).
