### PR TITLE
openEOPlatform/architecture-docs#266 Prevent duplicate links in merged collection metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is roughly based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Fixed
 
+- Merging of collection metadata produced duplicate entries in `links`: [openEOPlatform/architecture-docs#266](https://github.com/openEOPlatform/architecture-docs/issues/266)
 
 ## [0.6.x]
 

--- a/src/openeo_aggregator/metadata/merging.py
+++ b/src/openeo_aggregator/metadata/merging.py
@@ -82,11 +82,18 @@ def merge_collection_metadata(
 
     # Start with some initial/required fields
     result = {
-        "id": cid, "stac_version": max(list(getter.get("stac_version")) + ["0.9.0"]),
-        "title": getter.first("title", default = cid), "description": getter.first("description", default = cid),
-        "type": getter.first("type", default = "Collection"),
-        "links": [k for k in getter.concat("links") # TODO: report invalid links (e.g. string instead of dict)
-            if isinstance(k, dict) and k.get("rel") not in ("self", "parent", "root")],
+        "id": cid,
+        "stac_version": max(list(getter.get("stac_version")) + ["0.9.0"]),
+        "title": getter.first("title", default=cid),
+        "description": getter.first("description", default=cid),
+        "type": getter.first("type", default="Collection"),
+        "links": [
+            k
+            for k in getter.concat(
+                "links", skip_duplicates=True
+            )  # TODO: report invalid links (e.g. string instead of dict)
+            if isinstance(k, dict) and k.get("rel") not in ("self", "parent", "root")
+        ],
     }
 
     # Generic field merging

--- a/tests/metadata/test_merging.py
+++ b/tests/metadata/test_merging.py
@@ -1,7 +1,12 @@
 import pytest
 
-from openeo_aggregator.metadata.merging import ProcessMetadataMerger, json_diff
+from openeo_aggregator.metadata.merging import (
+    ProcessMetadataMerger,
+    json_diff,
+    merge_collection_metadata,
+)
 from openeo_aggregator.testing import same_repr
+from openeo_driver.backend import CollectionCatalog
 from openeo_driver.testing import DictSubSet
 
 
@@ -878,3 +883,67 @@ def test_json_diff_scalar_difference():
         b_name="changed",
         context=1,
     ) == ["--- orig\n", "+++ changed\n", "@@ -1 +1 @@\n", '-"string"\n', "+null\n"]
+
+
+def test_merge_collection_metadata_removes_duplicate_links():
+    """A simple test with just one collection that exists on two backends (and is identical on both)."""
+
+    root_url = "https://foo"
+    parent_url = root_url + "/collections"
+    self_url = parent_url + "/nvdi"
+
+    collection_metadata = {
+        "id": "NDVI",
+        "stac_version": "0.9.0",
+        "title": "title of NVDI",
+        "description": "Description of NVDI",
+        "type": "Collection",
+        "links": [
+            {
+                "href": f"{self_url}/about",
+                "rel": "about",
+                "title": "Website describing the collection",
+                "type": "text/html",
+            },
+            {
+                "href": f"{self_url}/somestuff/script.js",
+                "rel": "processing-expression",
+                "title": "Evalscript to do whatever",
+                "type": "application/javascript",
+            },
+            {
+                "href": self_url,
+                "rel": "self",
+            },
+            {
+                "href": parent_url,
+                "rel": "parent",
+            },
+            {
+                "href": root_url,
+                "rel": "root",
+            },
+        ],
+    }
+
+    by_backend = {"backend1": collection_metadata, "backend2": collection_metadata}
+
+    merged_actual = merge_collection_metadata(by_backend, full_metadata=True)
+    assert len(merged_actual["links"]) == 2
+
+    # If should keep only one copy of each link.
+    # But it should ignore links with relation "self", "parent" and "root"
+    assert merged_actual["links"] == [
+        {
+            "href": f"{self_url}/about",
+            "rel": "about",
+            "title": "Website describing the collection",
+            "type": "text/html",
+        },
+        {
+            "href": f"{self_url}/somestuff/script.js",
+            "rel": "processing-expression",
+            "title": "Evalscript to do whatever",
+            "type": "application/javascript",
+        },
+    ]

--- a/tests/metadata/test_merging.py
+++ b/tests/metadata/test_merging.py
@@ -885,10 +885,10 @@ def test_json_diff_scalar_difference():
     ) == ["--- orig\n", "+++ changed\n", "@@ -1 +1 @@\n", '-"string"\n', "+null\n"]
 
 
-def test_merge_collection_metadata_removes_duplicate_links():
-    """A simple test with just one collection that exists on two backends (and is identical on both)."""
+def test_merge_collection_metadata_removes_duplicate_links(backend1):
+    """A simple test with just one collection that exists on two backends (and it is identical on both)."""
 
-    root_url = "https://foo"
+    root_url = backend1 + "/collections"
     parent_url = root_url + "/collections"
     self_url = parent_url + "/nvdi"
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1576,15 +1576,15 @@ class TestAggregatorCollectionCatalog:
                 "id": "S2",
                 "links": [
                     {
-                        "href": "http://oeoa.test/openeo/1.1.0/collections",
+                        "href": f"{backend1}/collections",
                         "rel": "root",
                     },
                     {
-                        "href": "http://oeoa.test/openeo/1.1.0/collections",
+                        "href": f"{backend1}/collections",
                         "rel": "parent",
                     },
                     {
-                        "href": "http://oeoa.test/openeo/1.1.0/collections/S2",
+                        "href": f"{backend1}/collections/S2",
                         "rel": "self",
                     },
                     {"href": "http://some.license", "rel": "license"},
@@ -1601,15 +1601,15 @@ class TestAggregatorCollectionCatalog:
                 "id": "S2",
                 "links": [
                     {
-                        "href": "http://oeoa.test/openeo/1.1.0/collections/S2",
+                        "href": f"{backend2}/collections/S2",
                         "rel": "self",
                     },
                     {
-                        "href": "http://oeoa.test/openeo/1.1.0/collections",
+                        "href": f"{backend2}/collections",
                         "rel": "parent",
                     },
                     {
-                        "href": "http://oeoa.test/openeo/1.1.0/collections",
+                        "href": f"{backend2}/collections",
                         "rel": "root",
                     },
                     {"href": "http://some.license", "rel": "license"},

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1564,7 +1564,7 @@ class TestAggregatorCollectionCatalog:
             },
         }
 
-    def test_get_collection_metadata_merging_doesnt_cause_duplicate_links(
+    def test_get_collection_metadata_merging_removes_duplicate_links(
         self, catalog, backend1, backend2, requests_mock
     ):
         requests_mock.get(


### PR DESCRIPTION
Implements openEOPlatform/architecture-docs#266



