### PR TITLE
Issue63 add integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,53 @@ Which config to pick is determined through env variables:
 ### Logging
 
 Logging is set up (by default) through `config/logging-json.conf`.
+
+## Running tests
+
+You can run the unit tests with pytest, the usual way.
+
+    pytest
+
+This will only pick up the unit tests, which you can find in the directory `tests`.
+
+That is to say, when you run the command `pytest` without specifying a specific directory or file
+it will _not_ run the integration tests, only the unit tests.
+That is a deliberate choice because the integration tests could take long and they run
+against a backend server. We want to avoid that you have to wait a long time for each test run during your development cycle.
+
+So if you want integration tests then you have to run those separately, as described below.
+### Running integration tests
+
+To make it easier to run the integration test suite against the _default_ backend you can run the following shell script (from the root of your local git repository):
+
+    ./scripts/run-integration-tests.sh
+
+To run the integration test suite against any other OpenEO backend:
+
+- first, specify the backend base URL in environment variable `ENDPOINT` ,
+- then run the tests with `pytest integration-tests/`
+
+For example:
+
+    export ENDPOINT=http://localhost:8080/
+    pytest integration-tests/
+
+
+Pytest provides [various options](https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests)
+to run a subset or just a single test.
+Some examples (that can be combined):
+
+-   select by substring of the name of a test with the `-k` option:
+
+        # Run all tests with `collections` in their name
+        pytest -k collections
+
+### Debugging and troubleshooting tips
+
+- The `tmp_path` fixture provides a [fresh temporary folder for a test to work in](https://docs.pytest.org/en/latest/tmpdir.html).
+It is cleaned up automatically, except for the last 3 runs, so you can inspect
+generated files post-mortem. The temp folders are typically situated under `/tmp/pytest-of-$USERNAME`.
+
+- To disable pytest's default log/output capturing, to better see what is going on in "real time", add these options:
+
+        --capture=no --log-cli-level=INFO

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -1,0 +1,66 @@
+import os
+
+import openeo
+import pytest
+import requests
+from openeo.capabilities import ComparableVersion
+
+
+def get_openeo_base_url(version: str = "1.1.0"):
+    try:
+        endpoint = os.environ["ENDPOINT"].rstrip("/")
+    except Exception:
+        raise RuntimeError(
+            "Environment variable 'ENDPOINT' should be set"
+            " with URL pointing to OpenEO backend to test against"
+            " (e.g. 'http://localhost:8080/' or 'http://openeo-dev.vgt.vito.be/')"
+        )
+    return "{e}/openeo/{v}".format(e=endpoint.rstrip("/"), v=version)
+
+
+@pytest.fixture(
+    params=[
+        "1.1.0",
+    ]
+)
+def api_version(request) -> ComparableVersion:
+    return ComparableVersion(request.param)
+
+
+@pytest.fixture
+def api_base_url(api_version):
+    return get_openeo_base_url(str(api_version))
+
+
+@pytest.fixture
+def requests_session(request) -> requests.Session:
+    """
+    Fixture to create a `requests.Session` that automatically injects a query parameter in API URLs
+    referencing the currently running test.
+    Simplifies cross-referencing between integration tests and flask/YARN logs
+    """
+    session = requests.Session()
+    session.params["_origin"] = f"{request.session.name}/{request.node.name}"
+    return session
+
+
+@pytest.fixture
+def connection(api_base_url, requests_session) -> openeo.Connection:
+    return openeo.connect(api_base_url, session=requests_session)
+
+
+@pytest.fixture
+def connection100(requests_session) -> openeo.Connection:
+    return openeo.connect(get_openeo_base_url("1.0.0"), session=requests_session)
+
+
+# TODO: real authentication?
+TEST_USER = "jenkins"
+TEST_PASSWORD = TEST_USER + "123"
+
+
+@pytest.fixture
+def auth_connection(connection) -> openeo.Connection:
+    """Connection fixture to a backend of given version with some image collections."""
+    connection.authenticate_basic(TEST_USER, TEST_PASSWORD)
+    return connection

--- a/integration-tests/test_integration.py
+++ b/integration-tests/test_integration.py
@@ -1,0 +1,50 @@
+import logging
+
+import openeo
+import pytest
+
+_log = logging.getLogger(__name__)
+
+
+def test_openeo_cloud_root_return_sensible_response(connection: openeo.Connection):
+    """Check that ${ENDPOINT}/openeo/1.0/ returns something sensible."""
+    path = "/"
+    response = connection.get(path)
+
+    _log.info("As curl:\n" + connection.as_curl(data={}, path=path, method="GET"))
+    _log.info(f"{response=}")
+    _log.info(f"{response.json()=}")
+
+    response_body = response.json()
+    assert response.status_code == 200
+
+    required_keys = [
+        "api_version",
+        "backend_version",
+        "billing",
+        "description",
+        "endpoints",
+        "federation",
+        "id",
+        "links",
+        "processing:software",
+        "production",
+        "stac_extensions",
+        "stac_version",
+        "title",
+        "version",
+    ]
+    actual_keys_in_response = response_body.keys()
+    assert all([k in actual_keys_in_response for k in required_keys])
+
+
+@pytest.mark.xfail(reason="Not implemented yet")
+def test_collections():
+    """Does /collections look ok?"""
+    assert False
+
+
+@pytest.mark.xfail(reason="Not implemented yet")
+def test_processes():
+    """Does /processes look ok?"""
+    assert False

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -1,0 +1,2 @@
+export ENDPOINT=https://openeocloud.vito.be
+pytest -ra -vv integration-tests/


### PR DESCRIPTION
Issue #63

Backend can be set with the environment variable ENDPOINT, like we have in the GeoPySpark driver's integration tests.

There is also a shell script to run the integration tests with the default backend, https://openeocloud.vito.be:

```
./scripts/run-integration-tests.sh
```

Instructions to run the integration tests have been added to the README.md

