### PR TITLE
Issue106 update dependency and fix errors with get log entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is roughly based on [Keep a Changelog](https://keepachangelog.com/en/
 
 
 ### Changed
+- Support log level for retrieving BatchJob logs
+  ([#106](https://github.com/Open-EO/openeo-aggregator/issues/106))
 
 ### Fixed
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "requests",
         "attrs",
         "openeo>=0.16.0.a5.dev",
-        "openeo_driver>=0.38.1.dev",
+        "openeo_driver>=0.40.0a1.dev",
         "flask~=2.0",
         "gunicorn~=20.0",
         "python-json-logger>=2.0.0",

--- a/src/openeo_aggregator/backend.py
+++ b/src/openeo_aggregator/backend.py
@@ -803,11 +803,17 @@ class AggregatorBatchJobs(BatchJobs):
             links=links,
         )
 
-    def get_log_entries(self, job_id: str, user_id: str, offset: Optional[str] = None) -> List[dict]:
+    def get_log_entries(
+        self,
+        job_id: str,
+        user_id: str,
+        offset: Optional[str] = None,
+        level: Optional[str] = None,
+    ) -> Iterable[dict]:
         con, backend_job_id = self._get_connection_and_backend_job_id(aggregator_job_id=job_id)
         with con.authenticated_from_request(request=flask.request, user=User(user_id)), \
                 self._translate_job_errors(job_id=job_id):
-            return con.job(backend_job_id).logs(offset=offset)
+            return con.job(backend_job_id).logs(offset=offset, level=level)
 
 
 class ServiceIdMapping:


### PR DESCRIPTION
Fixes issue https://github.com/Open-EO/openeo-aggregator/issues/106

- Updated openeo_driver dependency from v0.38 to v0.40
- Updated some functions to support level and fix errors raised by get_log_entries