### PR TITLE
billing plans: disassociate from user role and don't list any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is roughly based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Current: 0.13.x]
--
+
+## [Current: 0.14.x]
+
+- Disassociate billing plans from user roles and don't list any for now ([openEOPlatform/architecture-docs#381](https://github.com/openEOPlatform/architecture-docs/issues/381))
+
+
+## [0.13.x]
+
 - Fix compatibility with `openeo_driver>=0.75.0` (new `enable_basic_auth` config, which is going to be disabled by default)
 
 

--- a/src/openeo_aggregator/about.py
+++ b/src/openeo_aggregator/about.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from typing import Optional
 
-__version__ = "0.13.0a1"
+__version__ = "0.14.0a1"
 
 
 def log_version_info(logger: Optional[logging.Logger] = None):

--- a/src/openeo_aggregator/backend.py
+++ b/src/openeo_aggregator/backend.py
@@ -1345,8 +1345,6 @@ class AggregatorBackendImplementation(OpenEoBackendImplementation):
             )
             if roles:
                 user.add_roles(r.id for r in roles)
-                # TODO: better way of determining default_plan?
-                user.set_default_plan([r.billing_plan for r in roles][-1].name)
             else:
                 _log.warning(f"user_access_validation failure: %r %r", enrollment_error_user_message, {
                     "user_id": user.user_id,
@@ -1391,15 +1389,6 @@ class AggregatorBackendImplementation(OpenEoBackendImplementation):
         # TODO #96 check that all upstream back-ends use the same currency (credits)
         return {
             "currency": "credits",
-            "plans": [
-                {
-                    "name": p.name,
-                    "description": p.description,
-                    "url": p.url,
-                    "paid": p.paid,
-                }
-                for p in openeo_aggregator.egi.OPENEO_PLATFORM_BILLING_PLANS
-            ]
         }
 
     def postprocess_capabilities(self, capabilities: dict) -> dict:

--- a/src/openeo_aggregator/egi.py
+++ b/src/openeo_aggregator/egi.py
@@ -11,35 +11,6 @@ from typing import List, Union
 BillingPlan = namedtuple("BillingPlan", ["name", "description", "url", "paid"])
 
 
-_BILLING_PLAN_30DAY_TRIAL = BillingPlan(
-    name="30day-trial",
-    description="openEO.cloud 30 day free trial plan (experimental)",
-    url="https://docs.openeo.cloud/join/free_trial.html",
-    paid=False,
-)
-
-_BILLING_PLAN_EARLY_ADOPTER = BillingPlan(
-    name="early-adopter",
-    description="openEO.cloud early adopter plan",
-    url="https://openeo.cloud/early-adopters/",
-    paid=True,
-)
-
-# TODO: avoid using generic billing plan
-_BILLING_PLAN_GENERIC = BillingPlan(
-    name="generic",
-    description="openEO.cloud generic plan",
-    url=None,
-    paid=True,
-)
-
-OPENEO_PLATFORM_BILLING_PLANS = [
-    _BILLING_PLAN_30DAY_TRIAL,
-    _BILLING_PLAN_EARLY_ADOPTER,
-    _BILLING_PLAN_GENERIC,
-]
-
-
 # Regex to parse eduperson_entitlement strings,
 # like for example "urn:mace:egi.eu:group:vo.openeo.cloud:role=early_adopter#aai.egi.eu"
 _eduperson_entitlement_regex = re.compile(
@@ -80,27 +51,19 @@ class UserRole:
         "_id",
         # Normalized version of role name (for case/whitespace-insensitive comparison)
         "_normalized",
-        # Associated billing plan
-        "_billing_plan",
     ]
 
-    def __init__(self, title: str, billing_plan: BillingPlan = _BILLING_PLAN_GENERIC):
+    def __init__(self, title: str):
         self._title = title
         self._id = "".join(
             w.title() if w.islower() else w
             for w in self._title.replace("-", " ").replace("_", " ").split()
         )
         self._normalized = self.normalize_role(self._title)
-        self._billing_plan = billing_plan
-
 
     @property
     def id(self) -> str:
         return self._id
-
-    @property
-    def billing_plan(self) -> BillingPlan:
-        return self._billing_plan
 
     @staticmethod
     def normalize_role(role: Union[str, None]) -> Union[str, None]:
@@ -137,8 +100,8 @@ class OpeneoPlatformUserRoles:
 # Based on https://github.com/openEOPlatform/documentation/issues/48
 OPENEO_PLATFORM_USER_ROLES = OpeneoPlatformUserRoles(
     [
-        UserRole("30-Day-Trial", billing_plan=_BILLING_PLAN_30DAY_TRIAL),
-        UserRole("Early_Adopter", billing_plan=_BILLING_PLAN_EARLY_ADOPTER),
+        UserRole("30-Day-Trial"),
+        UserRole("Early_Adopter"),
         # TODO: define a dedicated billing plan for each user role?
         UserRole("Basic_User"),
         UserRole("Professional_User"),

--- a/tests/test_egi.py
+++ b/tests/test_egi.py
@@ -53,7 +53,6 @@ class TestUserRole:
     def test_basic(self):
         role = UserRole("Foo")
         assert role.id == "Foo"
-        assert role.billing_plan.name == "generic"
         assert role.entitlement_match(
             "urn:mace:egi.eu:group:vo.openeo.cloud:role=Foo#aai.egi.eu"
         )


### PR DESCRIPTION
for  openEOPlatform/architecture-docs#381

- dissaociate billing plans from user roles
- don't list billing plans under `GET /`
- don't list default_plan under `GET /me`
- 